### PR TITLE
add sparse fieldset support via fields query param and nullable model fields

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -11,7 +11,7 @@ import (
 
 // Service defines the interface that all service types must implement
 type Service[T any, R any, L any] interface {
-	Get(ctx context.Context, id int) (*R, error)
+	Get(ctx context.Context, id int, params url.Values) (*R, error)
 	List(ctx context.Context, params url.Values) (*L, error)
 	Create(ctx context.Context, item *T) (*R, error)
 	Update(ctx context.Context, id int, item *T) (*R, error)
@@ -27,7 +27,7 @@ func Call[T any, R any, L any](ctx context.Context, service Service[T, R, L], ac
 		if id == 0 {
 			log.Fatal("ID is required for get action")
 		}
-		item, err := service.Get(ctx, id)
+		item, err := service.Get(ctx, id, nil)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/client/businesshours.go
+++ b/client/businesshours.go
@@ -20,8 +20,8 @@ func NewBusinessHourService(client *Client) *BusinessHourService {
 }
 
 // Get retrieves a businesshour by ID
-func (s *BusinessHourService) Get(ctx context.Context, id int) (*models.BusinessHourResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *BusinessHourService) Get(ctx context.Context, id int, params url.Values) (*models.BusinessHourResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of businesshours with optional filters

--- a/client/client.go
+++ b/client/client.go
@@ -153,6 +153,26 @@ func (c *Client) doRequest(ctx context.Context, req *http.Request) (*http.Respon
 	return handler(ctx, req)
 }
 
+// GetOptions represents options for single-resource get operations
+type GetOptions struct {
+	Fields   string
+	Includes string
+}
+
+// Values builds a url.Values from the options. Defaults includes to "all" when unset.
+func (o *GetOptions) Values() url.Values {
+	v := url.Values{}
+	includes := "all"
+	if o != nil && o.Includes != "" {
+		includes = o.Includes
+	}
+	v.Set("includes", includes)
+	if o != nil && o.Fields != "" {
+		v.Set("fields", o.Fields)
+	}
+	return v
+}
+
 // ListOptions represents options for list operations
 type ListOptions struct {
 	Page    int

--- a/client/companies.go
+++ b/client/companies.go
@@ -20,8 +20,8 @@ func NewCompanyService(client *Client) *CompanyService {
 }
 
 // Get retrieves a company by ID
-func (s *CompanyService) Get(ctx context.Context, id int) (*models.CompanyResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *CompanyService) Get(ctx context.Context, id int, params url.Values) (*models.CompanyResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of companies with optional filters

--- a/client/customers.go
+++ b/client/customers.go
@@ -20,8 +20,8 @@ func NewCustomerService(client *Client) *CustomerService {
 }
 
 // Get retrieves a customer by ID
-func (s *CustomerService) Get(ctx context.Context, id int) (*models.CustomerResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *CustomerService) Get(ctx context.Context, id int, params url.Values) (*models.CustomerResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of customers with optional filters

--- a/client/file.go
+++ b/client/file.go
@@ -37,8 +37,8 @@ func NewFileService(client *Client) *FileService {
 }
 
 // Get retrieves a file by ID
-func (s *FileService) Get(ctx context.Context, id int) (*models.FileResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *FileService) Get(ctx context.Context, id int, params url.Values) (*models.FileResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of files with optional filters
@@ -79,7 +79,11 @@ func (s *FileService) Upload(ctx context.Context, file *models.FileResponse, f [
 		}
 	}
 
-	part, err := writer.CreateFormFile("file", file.File.Filename)
+	filename := ""
+	if file.File.Filename != nil {
+		filename = *file.File.Filename
+	}
+	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return fmt.Errorf("create form file: %w", err)
 	}
@@ -91,7 +95,11 @@ func (s *FileService) Upload(ctx context.Context, file *models.FileResponse, f [
 
 	writer.Close()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, file.URL, &buf)
+	uploadURL := ""
+	if file.URL != nil {
+		uploadURL = *file.URL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
 	if err != nil {
 		return err
 	}

--- a/client/helpdocarticles.go
+++ b/client/helpdocarticles.go
@@ -20,8 +20,8 @@ func NewHelpDocArticleService(client *Client) *HelpDocArticleService {
 }
 
 // Get retrieves a help doc article by ID
-func (s *HelpDocArticleService) Get(ctx context.Context, id int) (*models.HelpDocArticleResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *HelpDocArticleService) Get(ctx context.Context, id int, params url.Values) (*models.HelpDocArticleResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of help doc articles with optional filters

--- a/client/helpdocsites.go
+++ b/client/helpdocsites.go
@@ -20,8 +20,8 @@ func NewHelpDocSiteService(client *Client) *HelpDocSiteService {
 }
 
 // Get retrieves a help doc site by ID
-func (s *HelpDocSiteService) Get(ctx context.Context, id int) (*models.HelpDocSiteResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *HelpDocSiteService) Get(ctx context.Context, id int, params url.Values) (*models.HelpDocSiteResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of help doc sites with optional filters

--- a/client/inboxes.go
+++ b/client/inboxes.go
@@ -20,8 +20,8 @@ func NewInboxService(client *Client) *InboxService {
 }
 
 // Get retrieves an inbox by ID
-func (s *InboxService) Get(ctx context.Context, id int) (*models.InboxResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *InboxService) Get(ctx context.Context, id int, params url.Values) (*models.InboxResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of inboxes with optional filters

--- a/client/messages.go
+++ b/client/messages.go
@@ -27,8 +27,8 @@ func NewMessageService(client *Client) *MessageService {
 }
 
 // Get retrieves a message by ID
-func (s *MessageService) Get(ctx context.Context, id int) (*models.MessageResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *MessageService) Get(ctx context.Context, id int, params url.Values) (*models.MessageResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of messages with optional filters

--- a/client/messages_test.go
+++ b/client/messages_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/teamwork/desksdkgo/models"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestMessageServiceCreateForTicket(t *testing.T) {
 	mockTransport := NewMockRoundTripper()
 	mockTransport.AddResponse(http.MethodPost, "/tickets/123/messages.json", http.StatusCreated, models.MessageResponse{
@@ -20,7 +22,7 @@ func TestMessageServiceCreateForTicket(t *testing.T) {
 	client := NewClient("https://example.com", WithHTTPClient(&http.Client{Transport: mockTransport}))
 
 	resp, err := client.Messages.CreateForTicket(context.Background(), 123, &models.MessageResponse{
-		Message: models.Message{Message: "hello"},
+		Message: models.Message{Message: ptr("hello")},
 	})
 	if err != nil {
 		t.Fatalf("CreateForTicket() returned error: %v", err)
@@ -58,7 +60,7 @@ func TestMessageServiceCreateUsesMessageTicketID(t *testing.T) {
 	_, err := client.Messages.Create(context.Background(), &models.MessageResponse{
 		Message: models.Message{
 			Ticket:  models.EntityRef{ID: 321},
-			Message: "reply",
+			Message: ptr("reply"),
 		},
 	})
 	if err != nil {
@@ -79,7 +81,7 @@ func TestMessageServiceCreateRequiresTicketID(t *testing.T) {
 	client := NewClient("https://example.com", WithHTTPClient(&http.Client{Transport: NewMockRoundTripper()}))
 
 	_, err := client.Messages.Create(context.Background(), &models.MessageResponse{
-		Message: models.Message{Message: "no ticket"},
+		Message: models.Message{Message: ptr("no ticket")},
 	})
 	if err == nil {
 		t.Fatal("expected error when ticket ID is missing")

--- a/client/resource.go
+++ b/client/resource.go
@@ -44,9 +44,12 @@ func (s *Service[T, L]) logError(msg string, attrs ...slog.Attr) {
 }
 
 // Get retrieves a resource by ID
-func (s *Service[T, L]) Get(ctx context.Context, id int) (*T, error) {
+func (s *Service[T, L]) Get(ctx context.Context, id int, params url.Values) (*T, error) {
+	if params == nil {
+		params = (&GetOptions{}).Values()
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		fmt.Sprintf("%s/%s.json?includes=all", s.client.baseURL, s.router.Get(id)), nil)
+		fmt.Sprintf("%s/%s.json?%s", s.client.baseURL, s.router.Get(id), params.Encode()), nil)
 	if err != nil {
 		s.logError("failed to create request", slog.Any("error", err))
 		return nil, err

--- a/client/slas.go
+++ b/client/slas.go
@@ -20,8 +20,8 @@ func NewSLAService(client *Client) *SLAService {
 }
 
 // Get retrieves a sla by ID
-func (s *SLAService) Get(ctx context.Context, id int) (*models.SLAResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *SLAService) Get(ctx context.Context, id int, params url.Values) (*models.SLAResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of slas with optional filters

--- a/client/spamlist.go
+++ b/client/spamlist.go
@@ -20,8 +20,8 @@ func NewSpamlistService(client *Client) *SpamlistService {
 }
 
 // Get retrieves a spamlist by ID
-func (s *SpamlistService) Get(ctx context.Context, id int) (*models.SpamlistResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *SpamlistService) Get(ctx context.Context, id int, params url.Values) (*models.SpamlistResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of spamlistes with optional filters

--- a/client/tags.go
+++ b/client/tags.go
@@ -20,8 +20,8 @@ func NewTagService(client *Client) *TagService {
 }
 
 // Get retrieves a tag by ID
-func (s *TagService) Get(ctx context.Context, id int) (*models.TagResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TagService) Get(ctx context.Context, id int, params url.Values) (*models.TagResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of tages with optional filters

--- a/client/ticketpriorities.go
+++ b/client/ticketpriorities.go
@@ -20,8 +20,8 @@ func NewTicketPriorityService(client *Client) *TicketPriorityService {
 }
 
 // Get retrieves a ticketpriority by ID
-func (s *TicketPriorityService) Get(ctx context.Context, id int) (*models.TicketPriorityResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TicketPriorityService) Get(ctx context.Context, id int, params url.Values) (*models.TicketPriorityResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of ticketpriorityes with optional filters

--- a/client/tickets.go
+++ b/client/tickets.go
@@ -29,8 +29,8 @@ func NewTicketService(client *Client) *TicketService {
 }
 
 // Get retrieves a ticket by ID
-func (s *TicketService) Get(ctx context.Context, id int) (*models.TicketResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TicketService) Get(ctx context.Context, id int, params url.Values) (*models.TicketResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of tickets with optional filters

--- a/client/ticketsources.go
+++ b/client/ticketsources.go
@@ -20,8 +20,8 @@ func NewTicketSourceService(client *Client) *TicketSourceService {
 }
 
 // Get retrieves a ticketsource by ID
-func (s *TicketSourceService) Get(ctx context.Context, id int) (*models.TicketSourceResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TicketSourceService) Get(ctx context.Context, id int, params url.Values) (*models.TicketSourceResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of ticketsources with optional filters

--- a/client/ticketstatuses.go
+++ b/client/ticketstatuses.go
@@ -20,8 +20,8 @@ func NewTicketStatusService(client *Client) *TicketStatusService {
 }
 
 // Get retrieves a ticketstatus by ID
-func (s *TicketStatusService) Get(ctx context.Context, id int) (*models.TicketStatusResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TicketStatusService) Get(ctx context.Context, id int, params url.Values) (*models.TicketStatusResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of ticketstatuses with optional filters

--- a/client/tickettypes.go
+++ b/client/tickettypes.go
@@ -20,8 +20,8 @@ func NewTicketTypeService(client *Client) *TicketTypeService {
 }
 
 // Get retrieves a tickettype by ID
-func (s *TicketTypeService) Get(ctx context.Context, id int) (*models.TicketTypeResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *TicketTypeService) Get(ctx context.Context, id int, params url.Values) (*models.TicketTypeResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of tickettypees with optional filters

--- a/client/users.go
+++ b/client/users.go
@@ -20,8 +20,8 @@ func NewUserService(client *Client) *UserService {
 }
 
 // Get retrieves a user by ID
-func (s *UserService) Get(ctx context.Context, id int) (*models.UserResponse, error) {
-	return s.Service.Get(ctx, id)
+func (s *UserService) Get(ctx context.Context, id int, params url.Values) (*models.UserResponse, error) {
+	return s.Service.Get(ctx, id, params)
 }
 
 // List retrieves a list of users with optional filters

--- a/main.go
+++ b/main.go
@@ -17,6 +17,16 @@ import (
 	"github.com/teamwork/desksdkgo/util"
 )
 
+func ptr[T any](v T) *T { return &v }
+
+func deref[T any](v *T) T {
+	if v == nil {
+		var zero T
+		return zero
+	}
+	return *v
+}
+
 func main() {
 	// Load environment variables from .env file
 	util.LoadEnv()
@@ -187,16 +197,16 @@ func generateData(
 				}
 
 				resp := &models.TicketResponse{Ticket: models.Ticket{
-					Subject:           gofakeit.Sentence(1),
-					PreviewText:       gofakeit.Paragraph(1, 2, 3, " "),
-					OriginalRecipient: gofakeit.Email(),
+					Subject:           ptr(gofakeit.Sentence(1)),
+					PreviewText:       ptr(gofakeit.Paragraph(1, 2, 3, " ")),
+					OriginalRecipient: ptr(gofakeit.Email()),
 					Inbox: &models.EntityRef{
 						ID: inboxes.Inboxes[0].ID,
 					},
 					Customer: &models.EntityRef{
 						ID: customers.Customers[0].ID,
 					},
-					Body: gofakeit.Paragraph(3, 5, 10, "\n"),
+					Body: ptr(gofakeit.Paragraph(3, 5, 10, "\n")),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.Ticket, jsonData)
@@ -208,9 +218,9 @@ func generateData(
 				email := gofakeit.Email()
 				resp := &models.CustomerResponse{
 					Customer: models.Customer{
-						FirstName: gofakeit.FirstName(),
-						LastName:  gofakeit.LastName(),
-						Email:     email,
+						FirstName: ptr(gofakeit.FirstName()),
+						LastName:  ptr(gofakeit.LastName()),
+						Email:     ptr(email),
 					},
 					Included: models.IncludedData{
 						Contacts: []models.Contact{
@@ -218,8 +228,8 @@ func generateData(
 								BaseEntity: models.BaseEntity{
 									Type: "email",
 								},
-								Value:  email,
-								IsMain: true,
+								Value:  ptr(email),
+								IsMain: ptr(true),
 							},
 						},
 					},
@@ -233,13 +243,13 @@ func generateData(
 			api.Call(ctx, c.Companies, action, id, func() *models.CompanyResponse {
 				resp := &models.CompanyResponse{
 					Company: models.Company{
-						Name:        gofakeit.Company(),
-						Description: gofakeit.Paragraph(1, 2, 3, " "),
+						Name:        ptr(gofakeit.Company()),
+						Description: ptr(gofakeit.Paragraph(1, 2, 3, " ")),
 					},
 					Included: models.IncludedData{
 						Domains: []models.Domain{
 							{
-								Name: gofakeit.DomainName(),
+								Name: ptr(gofakeit.DomainName()),
 							},
 						},
 					},
@@ -252,9 +262,9 @@ func generateData(
 		case "users":
 			api.Call(ctx, c.Users, action, id, func() *models.UserResponse {
 				resp := &models.UserResponse{User: models.User{
-					FirstName: gofakeit.FirstName(),
-					LastName:  gofakeit.LastName(),
-					Email:     gofakeit.Email(),
+					FirstName: ptr(gofakeit.FirstName()),
+					LastName:  ptr(gofakeit.LastName()),
+					Email:     ptr(gofakeit.Email()),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.User, jsonData)
@@ -264,7 +274,7 @@ func generateData(
 		case "tags":
 			api.Call(ctx, c.Tags, action, id, func() *models.TagResponse {
 				resp := &models.TagResponse{Tag: models.Tag{
-					Name: gofakeit.Word(),
+					Name: ptr(gofakeit.Word()),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.Tag, jsonData)
@@ -283,7 +293,7 @@ func generateData(
 				}
 
 				resp := &models.MessageResponse{Message: models.Message{
-					Message: gofakeit.Paragraph(1, 2, 5, " "),
+					Message: ptr(gofakeit.Paragraph(1, 2, 5, " ")),
 					Ticket: models.EntityRef{
 						ID: tickets.Tickets[0].ID,
 					},
@@ -299,10 +309,10 @@ func generateData(
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			f := &models.FileResponse{File: models.File{
-				Filename:    gofakeit.LoremIpsumWord() + "." + gofakeit.FileExtension(),
-				MIMEType:    "image/jpeg",
-				Type:        models.FileTypeAttachment,
-				Disposition: models.DispositionAttachment,
+				Filename:    ptr(gofakeit.LoremIpsumWord() + "." + gofakeit.FileExtension()),
+				MIMEType:    ptr("image/jpeg"),
+				Type:        ptr(models.FileTypeAttachment),
+				Disposition: ptr(models.DispositionAttachment),
 			}}
 			if jsonData != nil {
 				util.MergeJSONData(&f.File, jsonData)
@@ -322,8 +332,8 @@ func generateData(
 		case "spamlists":
 			api.Call(ctx, c.Spamlists, action, id, func() *models.SpamlistResponse {
 				resp := &models.SpamlistResponse{Spamlist: models.Spamlist{
-					Term: gofakeit.Email(),
-					Type: "blacklist",
+					Term: ptr(gofakeit.Email()),
+					Type: ptr("blacklist"),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.Spamlist, jsonData)
@@ -333,7 +343,7 @@ func generateData(
 		case "statuses":
 			api.Call(ctx, c.TicketStatuses, action, id, func() *models.TicketStatusResponse {
 				resp := &models.TicketStatusResponse{TicketStatus: models.TicketStatus{
-					Name: gofakeit.Word(),
+					Name: ptr(gofakeit.Word()),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.TicketStatus, jsonData)
@@ -343,7 +353,7 @@ func generateData(
 		case "types":
 			api.Call(ctx, c.TicketTypes, action, id, func() *models.TicketTypeResponse {
 				resp := &models.TicketTypeResponse{TicketType: models.TicketType{
-					Name: gofakeit.Word(),
+					Name: ptr(gofakeit.Word()),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.TicketType, jsonData)
@@ -353,8 +363,8 @@ func generateData(
 		case "priorities":
 			api.Call(ctx, c.TicketPriorities, action, id, func() *models.TicketPriorityResponse {
 				resp := &models.TicketPriorityResponse{TicketPriority: models.TicketPriority{
-					Name:  gofakeit.Word(),
-					Color: gofakeit.SafeColor(),
+					Name:  ptr(gofakeit.Word()),
+					Color: ptr(gofakeit.SafeColor()),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.TicketPriority, jsonData)
@@ -364,7 +374,7 @@ func generateData(
 		case "helpdocsites":
 			api.Call(ctx, c.HelpDocSites, action, id, func() *models.HelpDocSiteResponse {
 				resp := &models.HelpDocSiteResponse{HelpDocSite: models.HelpDocSite{
-					Name: gofakeit.Company() + " Help Center",
+					Name: ptr(gofakeit.Company() + " Help Center"),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.HelpDocSite, jsonData)
@@ -374,8 +384,8 @@ func generateData(
 		case "helpdocarticles":
 			api.Call(ctx, c.HelpDocArticles, action, id, func() *models.HelpDocArticleResponse {
 				resp := &models.HelpDocArticleResponse{HelpDocArticle: models.HelpDocArticle{
-					Title:    gofakeit.Sentence(5),
-					Contents: gofakeit.Paragraph(3, 5, 10, "\n"),
+					Title:    ptr(gofakeit.Sentence(5)),
+					Contents: ptr(gofakeit.Paragraph(3, 5, 10, "\n")),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.HelpDocArticle, jsonData)
@@ -385,8 +395,8 @@ func generateData(
 		case "businesshours":
 			api.Call(ctx, c.BusinessHours, action, id, func() *models.BusinessHourResponse {
 				resp := &models.BusinessHourResponse{BusinessHour: models.BusinessHour{
-					Name:      gofakeit.Company() + " Business Hours",
-					IsDefault: true,
+					Name:      ptr(gofakeit.Company() + " Business Hours"),
+					IsDefault: ptr(true),
 				}}
 				if jsonData != nil {
 					util.MergeJSONData(&resp.BusinessHour, jsonData)
@@ -405,9 +415,9 @@ func generateData(
 				}
 
 				resp := &models.InboxResponse{Inbox: models.Inbox{
-					Name:      gofakeit.Company() + " Inbox",
-					Email:     gofakeit.Email(),
-					LocalPart: strings.SplitN(gofakeit.Email(), "@", 2)[0],
+					Name:      ptr(gofakeit.Company() + " Inbox"),
+					Email:     ptr(gofakeit.Email()),
+					LocalPart: ptr(strings.SplitN(gofakeit.Email(), "@", 2)[0]),
 				}}
 
 				for _, user := range users.Users {
@@ -416,7 +426,7 @@ func generateData(
 							ID: user.ID,
 						},
 						Meta: models.InboxMeta{
-							Access: "write",
+							Access: ptr("write"),
 						},
 					})
 				}
@@ -484,7 +494,7 @@ func generateData(
 
 				resp := &models.SLAResponse{
 					SLA: models.SLA{
-						Name: gofakeit.Company() + " SLA Policy",
+						Name: ptr(gofakeit.Company() + " SLA Policy"),
 						BusinessHour: &models.EntityRef{
 							ID: businesshours.BusinessHours[0].ID,
 						},
@@ -492,16 +502,16 @@ func generateData(
 					Included: models.IncludedData{
 						SLANotifications: []models.SLANotification{
 							{
-								Condition:          models.SLANotificationConditionTypeWarning,
-								Type:               models.SLANotificationTypeFirstResponse,
-								Duration:           gofakeit.Number(1, 10),
-								NotifyAssignedUser: true,
+								Condition:          ptr(models.SLANotificationConditionTypeWarning),
+								Type:               ptr(models.SLANotificationTypeFirstResponse),
+								Duration:           ptr(gofakeit.Number(1, 10)),
+								NotifyAssignedUser: ptr(true),
 							},
 							{
-								Condition:          models.SLANotificationConditionTypeBreach,
-								Type:               models.SLANotificationTypeFirstResponse,
-								Duration:           0,
-								NotifyAssignedUser: true,
+								Condition:          ptr(models.SLANotificationConditionTypeBreach),
+								Type:               ptr(models.SLANotificationTypeFirstResponse),
+								Duration:           ptr(0),
+								NotifyAssignedUser: ptr(true),
 							},
 						},
 					},
@@ -509,9 +519,9 @@ func generateData(
 
 				for _, priority := range priorities.TicketPriorities {
 					resp.Included.SLAPriorities = append(resp.Included.SLAPriorities, models.SLATicketPriority{
-						Hours:       gofakeit.Number(1, 10),
-						Minutes:     gofakeit.Number(1, 59),
-						Description: "SLA for " + priority.Name,
+						Hours:       ptr(gofakeit.Number(1, 10)),
+						Minutes:     ptr(gofakeit.Number(1, 59)),
+						Description: ptr("SLA for " + deref(priority.Name)),
 						TicketPriority: &models.EntityRef{
 							ID: priority.ID,
 						},
@@ -519,9 +529,9 @@ func generateData(
 				}
 
 				resp.Included.SLAPriorities = append(resp.Included.SLAPriorities, models.SLATicketPriority{
-					Hours:       gofakeit.Number(1, 10),
-					Minutes:     gofakeit.Number(1, 59),
-					Description: "SLA for None",
+					Hours:       ptr(gofakeit.Number(1, 10)),
+					Minutes:     ptr(gofakeit.Number(1, 59)),
+					Description: ptr("SLA for None"),
 				})
 
 				for _, inbox := range inboxes.Inboxes {
@@ -529,7 +539,7 @@ func generateData(
 						Inbox: &models.EntityRef{
 							ID: inbox.ID,
 						},
-						Condition: models.SLAConditionOptionEqual,
+						Condition: ptr(models.SLAConditionOptionEqual),
 					})
 
 					if len(resp.Included.SLAInboxes) > 4 {
@@ -542,7 +552,7 @@ func generateData(
 						Company: &models.EntityRef{
 							ID: company.ID,
 						},
-						Condition: models.SLAConditionOptionEqual,
+						Condition: ptr(models.SLAConditionOptionEqual),
 					})
 
 					if len(resp.Included.SLACompanies) > 4 {
@@ -555,7 +565,7 @@ func generateData(
 						Customer: &models.EntityRef{
 							ID: customer.ID,
 						},
-						Condition: models.SLAConditionOptionEqual,
+						Condition: ptr(models.SLAConditionOptionEqual),
 					})
 
 					if len(resp.Included.SLACustomers) > 3 {
@@ -568,7 +578,7 @@ func generateData(
 						Tag: &models.EntityRef{
 							ID: tag.ID,
 						},
-						Condition: models.SLAConditionOptionEqual,
+						Condition: ptr(models.SLAConditionOptionEqual),
 					})
 
 					if len(resp.Included.SLATags) > 6 {

--- a/models/base.go
+++ b/models/base.go
@@ -19,7 +19,7 @@ type BaseEntity struct {
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 	CreatedBy *UserRef   `json:"createdBy,omitempty"`
 	UpdatedBy *UserRef   `json:"updatedBy,omitempty"`
-	State     State      `json:"state"`
+	State     *State     `json:"state,omitempty"`
 }
 
 type UserRef struct {

--- a/models/businesshour.go
+++ b/models/businesshour.go
@@ -4,11 +4,11 @@ package models
 type BusinessHour struct {
 	BaseEntity
 
-	Name              string `json:"name"`
-	Description       string `json:"description"`
-	IsDefault         bool   `json:"isDefault"`
-	TimezoneID        int64  `json:"timezoneId"`
-	TimezoneReference string `json:"timezone_name"`
+	Name              *string `json:"name,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	IsDefault         *bool   `json:"isDefault,omitempty"`
+	TimezoneID        *int64  `json:"timezoneId,omitempty"`
+	TimezoneReference *string `json:"timezone_name,omitempty"`
 }
 
 // BusinessHoursResponse represents the response for a list of businesshours

--- a/models/company.go
+++ b/models/company.go
@@ -3,33 +3,33 @@ package models
 // Phone represents a phone number associated with a company
 type Phone struct {
 	BaseEntity
-	Number      string `json:"number"`
-	Type        string `json:"type"`
-	CountryCode string `json:"countryCode"`
-	Extension   string `json:"extension"`
+	Number      *string `json:"number,omitempty"`
+	Type        *string `json:"type,omitempty"`
+	CountryCode *string `json:"countryCode,omitempty"`
+	Extension   *string `json:"extension,omitempty"`
 }
 
 // Domain represents a domain associated with a company
 type Domain struct {
 	BaseEntity
-	Name            string `json:"name"`
-	Project         any    `json:"project"`
-	Company         any    `json:"company"`
-	ProjectsCompany any    `json:"projects_company"`
+	Name            *string `json:"name,omitempty"`
+	Project         any     `json:"project"`
+	Company         any     `json:"company"`
+	ProjectsCompany any     `json:"projects_company"`
 }
 
 // Company represents a company in Desk.com
 type Company struct {
 	BaseEntity
-	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
-	Details     string      `json:"details"`
-	Industry    string      `json:"industry"`
-	Website     string      `json:"website"`
-	Permission  string      `json:"permission"`
-	Kind        string      `json:"kind"`
+	Name        *string     `json:"name,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	Details     *string     `json:"details,omitempty"`
+	Industry    *string     `json:"industry,omitempty"`
+	Website     *string     `json:"website,omitempty"`
+	Permission  *string     `json:"permission,omitempty"`
+	Kind        *string     `json:"kind,omitempty"`
 	Domains     []EntityRef `json:"domains,omitempty"`
-	Note        string      `json:"note,omitempty"`
+	Note        *string     `json:"note,omitempty"`
 }
 
 // CompaniesResponse represents the response for a list of companies

--- a/models/contact.go
+++ b/models/contact.go
@@ -3,6 +3,6 @@ package models
 // Contact related types
 type Contact struct {
 	BaseEntity
-	Value  string `json:"value"`
-	IsMain bool   `json:"isMain"`
+	Value  *string `json:"value,omitempty"`
+	IsMain *bool   `json:"isMain,omitempty"`
 }

--- a/models/customer.go
+++ b/models/customer.go
@@ -3,27 +3,27 @@ package models
 // Customer related types
 type Customer struct {
 	BaseEntity
-	FirstName             string      `json:"firstName"`
-	LastName              string      `json:"lastName"`
-	Email                 string      `json:"email"`
-	Organization          string      `json:"organization"`
-	ExtraData             string      `json:"extraData"`
-	Notes                 string      `json:"notes"`
-	VerifiedEmail         bool        `json:"verifiedEmail"`
-	LinkedinURL           string      `json:"linkedinURL"`
-	FacebookURL           string      `json:"facebookURL"`
-	TwitterHandle         string      `json:"twitterHandle"`
-	NumTickets            int         `json:"numTickets"`
+	FirstName             *string     `json:"firstName,omitempty"`
+	LastName              *string     `json:"lastName,omitempty"`
+	Email                 *string     `json:"email,omitempty"`
+	Organization          *string     `json:"organization,omitempty"`
+	ExtraData             *string     `json:"extraData,omitempty"`
+	Notes                 *string     `json:"notes,omitempty"`
+	VerifiedEmail         *bool       `json:"verifiedEmail,omitempty"`
+	LinkedinURL           *string     `json:"linkedinURL,omitempty"`
+	FacebookURL           *string     `json:"facebookURL,omitempty"`
+	TwitterHandle         *string     `json:"twitterHandle,omitempty"`
+	NumTickets            *int        `json:"numTickets,omitempty"`
 	JobTitle              any         `json:"jobTitle"`
-	Phone                 string      `json:"phone"`
-	Mobile                string      `json:"mobile"`
-	Address               string      `json:"address"`
-	ExternalID            string      `json:"externalId"`
-	AvatarURL             string      `json:"avatarURL"`
+	Phone                 *string     `json:"phone,omitempty"`
+	Mobile                *string     `json:"mobile,omitempty"`
+	Address               *string     `json:"address,omitempty"`
+	ExternalID            *string     `json:"externalId,omitempty"`
+	AvatarURL             *string     `json:"avatarURL,omitempty"`
 	Contacts              []EntityRef `json:"contacts"`
 	Customerwelcomeemails any         `json:"customerwelcomeemails"`
-	Trusted               bool        `json:"trusted"`
-	WelcomeEmailSent      bool        `json:"welcomeEmailSent"`
+	Trusted               *bool       `json:"trusted,omitempty"`
+	WelcomeEmailSent      *bool       `json:"welcomeEmailSent,omitempty"`
 }
 
 // Response types for customers

--- a/models/file.go
+++ b/models/file.go
@@ -18,16 +18,16 @@ const (
 type File struct {
 	BaseEntity
 	// Standard mime type of the file
-	MIMEType string `json:"mimeType"`
+	MIMEType *string `json:"mimeType,omitempty"`
 
 	// The file name
-	Filename string `json:"filename"`
+	Filename *string `json:"filename,omitempty"`
 
 	// Determine where the attachment was added: attachment or attachment-inline
-	Disposition Disposition `json:"disposition"`
+	Disposition *Disposition `json:"disposition,omitempty"`
 
 	// Type is always 'attachment'
-	Type FileType `json:"type"`
+	Type *FileType `json:"type,omitempty"`
 }
 
 type FilesResponse struct {
@@ -40,7 +40,7 @@ type FilesResponse struct {
 // RefResponse is the data gotten back from the /files/ref endpoint to then post
 // to s3
 type FileResponse struct {
-	URL    string     `json:"url"`
+	URL    *string    `json:"url,omitempty"`
 	Params FileParams `json:"params"`
 	File   File       `json:"file"`
 }

--- a/models/helpdocarticle.go
+++ b/models/helpdocarticle.go
@@ -3,17 +3,17 @@ package models
 type HelpDocArticle struct {
 	BaseEntity
 	Helpdocsite     EntityRef `json:"helpdocsite"`
-	Title           string    `json:"title"`
-	Slug            string    `json:"slug"`
-	Description     string    `json:"description"`
-	OldURL          string    `json:"oldURL"`
-	Popularity      int       `json:"popularity"`
-	DisqusEnabled   bool      `json:"disqusEnabled"`
-	IsPrivate       bool      `json:"isPrivate"`
-	EditMethod      string    `json:"editMethod"`
-	DisplayOrder    int       `json:"displayOrder"`
-	Status          string    `json:"status"`
-	Contents        string    `json:"contents"`
+	Title           *string   `json:"title,omitempty"`
+	Slug            *string   `json:"slug,omitempty"`
+	Description     *string   `json:"description,omitempty"`
+	OldURL          *string   `json:"oldURL,omitempty"`
+	Popularity      *int      `json:"popularity,omitempty"`
+	DisqusEnabled   *bool     `json:"disqusEnabled,omitempty"`
+	IsPrivate       *bool     `json:"isPrivate,omitempty"`
+	EditMethod      *string   `json:"editMethod,omitempty"`
+	DisplayOrder    *int      `json:"displayOrder,omitempty"`
+	Status          *string   `json:"status,omitempty"`
+	Contents        *string   `json:"contents,omitempty"`
 	Categories      []int     `json:"categories"`
 	RelatedArticles []int     `json:"relatedArticles,omitempty"`
 }

--- a/models/helpdocsite.go
+++ b/models/helpdocsite.go
@@ -2,52 +2,52 @@ package models
 
 type HelpDocSite struct {
 	BaseEntity
-	Name                 string           `json:"name"`
-	Description          string           `json:"description"`
-	MetaSiteDescription  string           `json:"metaSiteDescription"`
-	Subdomain            string           `json:"subdomain"`
-	ContactFormEnabled   bool             `json:"contactFormEnabled"`
-	ShowDateLastModified bool             `json:"showDateLastModified"`
-	CustomDomain         string           `json:"customDomain"`
-	CustomStyleSheet     string           `json:"customStyleSheet"`
-	HomePageLinkEnabled  bool             `json:"homePageLinkEnabled"`
-	HomePageLinkText     string           `json:"homePageLinkText"`
-	HomePageURL          string           `json:"homePageURL"`
-	HTMLHeadCode         string           `json:"htmlHeadCode"`
-	LogoImage            string           `json:"logoImage"`
-	Favicon              string           `json:"favicon"`
-	TouchIcon            string           `json:"touchIcon"`
-	PublicSiteEnabled    bool             `json:"publicSiteEnabled"`
-	SendEmailsToInboxID  int              `json:"sendEmailsToInboxId"`
-	ShowOnHomePage       string           `json:"showOnHomePage"`
-	HeaderBGColor        string           `json:"headerBGColor"`
-	NavActiveColor       string           `json:"navActiveColor"`
-	NavTextColor         string           `json:"navTextColor"`
-	PageBGColor          string           `json:"pageBGColor"`
-	LinkColor            string           `json:"linkColor"`
-	TextColor            string           `json:"textColor"`
-	LanguageCode         string           `json:"languageCode"`
-	Password             string           `json:"password"`
-	ShowSocialIcons      bool             `json:"showSocialIcons"`
+	Name                 *string          `json:"name,omitempty"`
+	Description          *string          `json:"description,omitempty"`
+	MetaSiteDescription  *string          `json:"metaSiteDescription,omitempty"`
+	Subdomain            *string          `json:"subdomain,omitempty"`
+	ContactFormEnabled   *bool            `json:"contactFormEnabled,omitempty"`
+	ShowDateLastModified *bool            `json:"showDateLastModified,omitempty"`
+	CustomDomain         *string          `json:"customDomain,omitempty"`
+	CustomStyleSheet     *string          `json:"customStyleSheet,omitempty"`
+	HomePageLinkEnabled  *bool            `json:"homePageLinkEnabled,omitempty"`
+	HomePageLinkText     *string          `json:"homePageLinkText,omitempty"`
+	HomePageURL          *string          `json:"homePageURL,omitempty"`
+	HTMLHeadCode         *string          `json:"htmlHeadCode,omitempty"`
+	LogoImage            *string          `json:"logoImage,omitempty"`
+	Favicon              *string          `json:"favicon,omitempty"`
+	TouchIcon            *string          `json:"touchIcon,omitempty"`
+	PublicSiteEnabled    *bool            `json:"publicSiteEnabled,omitempty"`
+	SendEmailsToInboxID  *int             `json:"sendEmailsToInboxId,omitempty"`
+	ShowOnHomePage       *string          `json:"showOnHomePage,omitempty"`
+	HeaderBGColor        *string          `json:"headerBGColor,omitempty"`
+	NavActiveColor       *string          `json:"navActiveColor,omitempty"`
+	NavTextColor         *string          `json:"navTextColor,omitempty"`
+	PageBGColor          *string          `json:"pageBGColor,omitempty"`
+	LinkColor            *string          `json:"linkColor,omitempty"`
+	TextColor            *string          `json:"textColor,omitempty"`
+	LanguageCode         *string          `json:"languageCode,omitempty"`
+	Password             *string          `json:"password,omitempty"`
+	ShowSocialIcons      *bool            `json:"showSocialIcons,omitempty"`
 	DisqusShortname      any              `json:"disqusShortname"`
-	AuthenticationType   string           `json:"authenticationType"`
-	AuthenticationTypeID int              `json:"authenticationTypeId"`
-	EditMethod           string           `json:"editMethod"`
-	Stats                HelpDocSiteStats `json:"stats"`
-	SearchTemplate       string           `json:"searchTemplate"`
-	HomeTemplate         string           `json:"homeTemplate"`
-	HeadTemplate         string           `json:"headTemplate"`
-	FooterTemplate       string           `json:"footerTemplate"`
-	CategoryTemplate     string           `json:"categoryTemplate"`
-	ArticleTemplate      string           `json:"articleTemplate"`
+	AuthenticationType   *string          `json:"authenticationType,omitempty"`
+	AuthenticationTypeID *int             `json:"authenticationTypeId,omitempty"`
+	EditMethod           *string          `json:"editMethod,omitempty"`
+	Stats                *HelpDocSiteStats `json:"stats,omitempty"`
+	SearchTemplate       *string          `json:"searchTemplate,omitempty"`
+	HomeTemplate         *string          `json:"homeTemplate,omitempty"`
+	HeadTemplate         *string          `json:"headTemplate,omitempty"`
+	FooterTemplate       *string          `json:"footerTemplate,omitempty"`
+	CategoryTemplate     *string          `json:"categoryTemplate,omitempty"`
+	ArticleTemplate      *string          `json:"articleTemplate,omitempty"`
 	Contributors         []EntityRef      `json:"contributors"`
 }
 
 type HelpDocSiteStats struct {
-	ArticleCount     int `json:"articleCount"`
-	PublishedCount   int `json:"publishedCount"`
-	UnpublishedCount int `json:"unpublishedCount"`
-	DraftCount       int `json:"draftCount"`
+	ArticleCount     *int `json:"articleCount,omitempty"`
+	PublishedCount   *int `json:"publishedCount,omitempty"`
+	UnpublishedCount *int `json:"unpublishedCount,omitempty"`
+	DraftCount       *int `json:"draftCount,omitempty"`
 }
 
 type HelpDocSitesResponse struct {

--- a/models/inbox.go
+++ b/models/inbox.go
@@ -3,57 +3,57 @@ package models
 // Inbox related types
 type Inbox struct {
 	BaseEntity
-	AutoReplyEnabled              bool         `json:"autoReplyEnabled"`
-	AutoReplyMessage              string       `json:"autoReplyMessage"`
-	AutoReplySubject              string       `json:"autoReplySubject"`
-	ClientOnly                    bool         `json:"clientOnly"`
-	DisplayOrder                  int          `json:"displayOrder"`
-	Email                         string       `json:"email"`
-	EmailForwardingState          string       `json:"emailForwardingState"`
-	ForwardingAddress             string       `json:"forwardingAddress"`
-	HappinessRatingEnabled        bool         `json:"happinessRatingEnabled"`
-	HappinessRatingMessage        string       `json:"happinessRatingMessage"`
-	IconImage                     string       `json:"iconImage"`
+	AutoReplyEnabled              *bool        `json:"autoReplyEnabled,omitempty"`
+	AutoReplyMessage              *string      `json:"autoReplyMessage,omitempty"`
+	AutoReplySubject              *string      `json:"autoReplySubject,omitempty"`
+	ClientOnly                    *bool        `json:"clientOnly,omitempty"`
+	DisplayOrder                  *int         `json:"displayOrder,omitempty"`
+	Email                         *string      `json:"email,omitempty"`
+	EmailForwardingState          *string      `json:"emailForwardingState,omitempty"`
+	ForwardingAddress             *string      `json:"forwardingAddress,omitempty"`
+	HappinessRatingEnabled        *bool        `json:"happinessRatingEnabled,omitempty"`
+	HappinessRatingMessage        *string      `json:"happinessRatingMessage,omitempty"`
+	IconImage                     *string      `json:"iconImage,omitempty"`
 	Inboxaliases                  []EntityRef  `json:"inboxaliases"`
 	Inboxcnames                   []InboxCname `json:"inboxcnames"`
 	Inboxemailrefs                any          `json:"inboxemailrefs"`
-	IncludeTicketHistoryOnForward bool         `json:"includeTicketHistoryOnForward"`
-	IsAdmin                       bool         `json:"isAdmin"`
-	IsFreeDomain                  bool         `json:"isFreeDomain"`
-	LanguageCode                  string       `json:"languageCode"`
-	LocalPart                     string       `json:"localPart"`
-	Name                          string       `json:"name"`
-	NotificationsOnly             bool         `json:"notificationsOnly"`
+	IncludeTicketHistoryOnForward *bool        `json:"includeTicketHistoryOnForward,omitempty"`
+	IsAdmin                       *bool        `json:"isAdmin,omitempty"`
+	IsFreeDomain                  *bool        `json:"isFreeDomain,omitempty"`
+	LanguageCode                  *string      `json:"languageCode,omitempty"`
+	LocalPart                     *string      `json:"localPart,omitempty"`
+	Name                          *string      `json:"name,omitempty"`
+	NotificationsOnly             *bool        `json:"notificationsOnly,omitempty"`
 	Oauth2Token                   any          `json:"oauth2token"`
-	OnClosedLock                  string       `json:"onClosedLock"`
-	OnClosedWait                  int          `json:"onClosedWait"`
+	OnClosedLock                  *string      `json:"onClosedLock,omitempty"`
+	OnClosedWait                  *int         `json:"onClosedWait,omitempty"`
 	Projects                      []EntityRef  `json:"projects"`
-	PublicIconImage               string       `json:"publicIconImage"`
+	PublicIconImage               *string      `json:"publicIconImage,omitempty"`
 	Restricteddomains             any          `json:"restricteddomains"`
-	SendEmailsFrom                string       `json:"sendEmailsFrom"`
-	Signature                     string       `json:"signature"`
-	SMTPPassword                  string       `json:"smtpPassword"`
-	SMTPPort                      int          `json:"smtpPort"`
-	SMTPProvider                  string       `json:"smtpProvider"`
-	SMTPSecurity                  string       `json:"smtpSecurity"`
-	SMTPServer                    string       `json:"smtpServer"`
-	SMTPUsername                  string       `json:"smtpUsername"`
-	SpamThreshold                 int          `json:"spamThreshold"`
-	Starred                       bool         `json:"starred"`
+	SendEmailsFrom                *string      `json:"sendEmailsFrom,omitempty"`
+	Signature                     *string      `json:"signature,omitempty"`
+	SMTPPassword                  *string      `json:"smtpPassword,omitempty"`
+	SMTPPort                      *int         `json:"smtpPort,omitempty"`
+	SMTPProvider                  *string      `json:"smtpProvider,omitempty"`
+	SMTPSecurity                  *string      `json:"smtpSecurity,omitempty"`
+	SMTPServer                    *string      `json:"smtpServer,omitempty"`
+	SMTPUsername                  *string      `json:"smtpUsername,omitempty"`
+	SpamThreshold                 *int         `json:"spamThreshold,omitempty"`
+	Starred                       *bool        `json:"starred,omitempty"`
 	SyncAccountID                 any          `json:"syncAccountId"`
 	SyncDays                      any          `json:"syncDays"`
-	Synced                        bool         `json:"synced"`
+	Synced                        *bool        `json:"synced,omitempty"`
 	SyncSubscriptionID            any          `json:"syncSubscriptionId"`
-	Ticketstatus                  EntityRef    `json:"ticketstatus"`
+	Ticketstatus                  *EntityRef   `json:"ticketstatus,omitempty"`
 	Tickettypes                   []EntityRef  `json:"tickettypes"`
-	TimeloggingEnabled            bool         `json:"timeloggingEnabled"`
+	TimeloggingEnabled            *bool        `json:"timeloggingEnabled,omitempty"`
 	Triggers                      []Trigger    `json:"triggers"`
-	Type                          string       `json:"type"`
+	Type                          *string      `json:"type,omitempty"`
 	User                          any          `json:"user"`
 	Users                         []InboxUser  `json:"users"`
-	UseTeamworkMailServer         bool         `json:"useTeamworkMailServer"`
-	UsingOfficeHours              bool         `json:"usingOfficeHours"`
-	Verified                      bool         `json:"verified"`
+	UseTeamworkMailServer         *bool        `json:"useTeamworkMailServer,omitempty"`
+	UsingOfficeHours              *bool        `json:"usingOfficeHours,omitempty"`
+	Verified                      *bool        `json:"verified,omitempty"`
 }
 
 type InboxesResponse struct {
@@ -74,22 +74,22 @@ type InboxUser struct {
 }
 
 type InboxMeta struct {
-	Access  string `json:"access"`
-	IsAdmin bool   `json:"isAdmin"`
-	Starred bool   `json:"starred"`
-	State   string `json:"state"`
+	Access  *string `json:"access,omitempty"`
+	IsAdmin *bool   `json:"isAdmin,omitempty"`
+	Starred *bool   `json:"starred,omitempty"`
+	State   *string `json:"state,omitempty"`
 }
 
 type Trigger struct {
 	EntityRef
 	Meta struct {
-		DisplayOrder int `json:"displayOrder"`
+		DisplayOrder *int `json:"displayOrder,omitempty"`
 	} `json:"meta"`
 }
 
 type InboxCname struct {
 	EntityRef
 	Meta struct {
-		Domain string `json:"domain"`
+		Domain *string `json:"domain,omitempty"`
 	} `json:"meta"`
 }

--- a/models/message.go
+++ b/models/message.go
@@ -8,16 +8,16 @@ import (
 // Message related types
 type Message struct {
 	BaseEntity
-	AssigningUser      EntityRef  `json:"assigningUser,omitempty"`
+	AssigningUser      *EntityRef `json:"assigningUser,omitempty"`
 	BCC                []string   `json:"bcc"`
 	CC                 []string   `json:"cc"`
-	Contact            EntityRef  `json:"contact,omitempty"`
-	Delayed            bool       `json:"delayed"`
-	EditMethod         string     `json:"editMethod"`
-	Message            string     `json:"message"`
-	IsPinned           bool       `json:"isPinned"`
-	Status             EntityRef  `json:"status,omitempty"`
-	ThreadType         string     `json:"threadType"`
+	Contact            *EntityRef `json:"contact,omitempty"`
+	Delayed            *bool      `json:"delayed,omitempty"`
+	EditMethod         *string    `json:"editMethod,omitempty"`
+	Message            *string    `json:"message,omitempty"`
+	IsPinned           *bool      `json:"isPinned,omitempty"`
+	Status             *EntityRef `json:"status,omitempty"`
+	ThreadType         *string    `json:"threadType,omitempty"`
 	Ticket             EntityRef  `json:"ticket"`
 	ViewedByCustomerAt *time.Time `json:"viewedByCustomerAt"`
 }
@@ -25,7 +25,7 @@ type Message struct {
 func (m *Message) UnmarshalJSON(data []byte) error {
 	type Alias Message
 	aux := &struct {
-		HtmlBody string `json:"htmlBody"`
+		HtmlBody *string `json:"htmlBody"`
 		*Alias
 	}{
 		Alias: (*Alias)(m),

--- a/models/sla.go
+++ b/models/sla.go
@@ -25,10 +25,10 @@ const (
 // SLA represents a SLA in the system
 type SLA struct {
 	BaseEntity
-	Name             string      `json:"name"`
-	Description      string      `json:"description"`
-	DisplayOrder     int         `json:"displayOrder"`
-	Enabled          bool        `json:"enabled"`
+	Name             *string     `json:"name,omitempty"`
+	Description      *string     `json:"description,omitempty"`
+	DisplayOrder     *int        `json:"displayOrder,omitempty"`
+	Enabled          *bool       `json:"enabled,omitempty"`
 	BusinessHour     *EntityRef  `json:"businesshours,omitempty"`
 	Customers        []EntityRef `json:"slacustomers"`
 	Companies        []EntityRef `json:"slacompanies"`
@@ -42,43 +42,43 @@ type SLA struct {
 
 type SLANotification struct {
 	BaseEntity
-	Condition          SLANotificationConditionType `json:"condition" db:"condition"`
-	Type               SLANotificationType          `json:"type"`
-	Duration           int                          `json:"duration"`
-	User               *EntityRef                   `json:"user,omitempty"`
-	NotifyAssignedUser bool                         `json:"notifyAssignedUser"`
+	Condition          *SLANotificationConditionType `json:"condition,omitempty" db:"condition"`
+	Type               *SLANotificationType          `json:"type,omitempty"`
+	Duration           *int                          `json:"duration,omitempty"`
+	User               *EntityRef                    `json:"user,omitempty"`
+	NotifyAssignedUser *bool                         `json:"notifyAssignedUser,omitempty"`
 }
 
 type SLATicketPriority struct {
 	BaseEntity
-	Hours          int        `json:"hours"`
-	Minutes        int        `json:"minutes"`
-	Description    string     `json:"description"`
+	Hours          *int       `json:"hours,omitempty"`
+	Minutes        *int       `json:"minutes,omitempty"`
+	Description    *string    `json:"description,omitempty"`
 	TicketPriority *EntityRef `json:"priority"`
 }
 
 type SLACustomer struct {
 	BaseEntity
-	Customer  *EntityRef         `json:"customer"`
-	Condition SLAConditionOption `json:"conditionoption" db:"conditionoption"`
+	Customer  *EntityRef          `json:"customer"`
+	Condition *SLAConditionOption `json:"conditionoption,omitempty" db:"conditionoption"`
 }
 
 type SLACompany struct {
 	BaseEntity
-	Company   *EntityRef         `json:"company"`
-	Condition SLAConditionOption `json:"conditionoption" db:"conditionoption"`
+	Company   *EntityRef          `json:"company"`
+	Condition *SLAConditionOption `json:"conditionoption,omitempty" db:"conditionoption"`
 }
 
 type SLAInbox struct {
 	BaseEntity
-	Inbox     *EntityRef         `json:"inbox"`
-	Condition SLAConditionOption `json:"conditionoption" db:"conditionoption"`
+	Inbox     *EntityRef          `json:"inbox"`
+	Condition *SLAConditionOption `json:"conditionoption,omitempty" db:"conditionoption"`
 }
 
 type SLATag struct {
 	BaseEntity
-	Tag       *EntityRef         `json:"tag"`
-	Condition SLAConditionOption `json:"conditionoption" db:"conditionoption"`
+	Tag       *EntityRef          `json:"tag"`
+	Condition *SLAConditionOption `json:"conditionoption,omitempty" db:"conditionoption"`
 }
 
 // SLAsResponse represents the response for a list of slas

--- a/models/spamlist.go
+++ b/models/spamlist.go
@@ -4,8 +4,8 @@ package models
 // or IP address.  Type is whitelist or blacklist.
 type Spamlist struct {
 	BaseEntity
-	Term string `json:"term"`
-	Type string `json:"type"`
+	Term *string `json:"term,omitempty"`
+	Type *string `json:"type,omitempty"`
 }
 
 // SpamlistsResponse represents the response for a list of spam lists

--- a/models/tag.go
+++ b/models/tag.go
@@ -3,8 +3,8 @@ package models
 // Tag represents a tag in the system
 type Tag struct {
 	BaseEntity
-	Name  string `json:"name"`
-	Color string `json:"color"`
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
 }
 
 // TagsResponse represents the response for a list of tags

--- a/models/ticket.go
+++ b/models/ticket.go
@@ -8,29 +8,29 @@ type Ticket struct {
 	Activities            []EntityRef `json:"activities,omitempty"`
 	Agent                 *EntityRef  `json:"agent,omitempty"`
 	BCC                   []string    `json:"bcc,omitempty"`
-	Body                  string      `json:"message"`
+	Body                  *string     `json:"message,omitempty"`
 	CC                    []string    `json:"cc,omitempty"`
 	Contact               *EntityRef  `json:"contact,omitempty"`
 	Customer              *EntityRef  `json:"customer,omitempty"`
 	Files                 []EntityRef `json:"files,omitempty"`
 	HappinessSurveySentAt *time.Time  `json:"happinessSurveySentAt"`
-	ImagesHidden          bool        `json:"imagesHidden"`
+	ImagesHidden          *bool       `json:"imagesHidden,omitempty"`
 	Inbox                 *EntityRef  `json:"inbox,omitempty"`
-	IsRead                bool        `json:"isRead"`
-	MessageCount          int         `json:"messageCount"`
+	IsRead                *bool       `json:"isRead,omitempty"`
+	MessageCount          *int        `json:"messageCount,omitempty"`
 	Messages              []EntityRef `json:"messages,omitempty"`
-	NotifyCustomer        bool        `json:"notifyCustomer"`
-	OriginalRecipient     string      `json:"originalRecipient"`
-	PreviewText           string      `json:"previewText"`
+	NotifyCustomer        *bool       `json:"notifyCustomer,omitempty"`
+	OriginalRecipient     *string     `json:"originalRecipient,omitempty"`
+	PreviewText           *string     `json:"previewText,omitempty"`
 	Priority              *EntityRef  `json:"priority,omitempty"`
-	Readonly              bool        `json:"readonly"`
-	ResolutionTimeMins    int         `json:"resolutionTimeMins"`
-	ResponseTimeMins      int         `json:"responseTimeMins"`
+	Readonly              *bool       `json:"readonly,omitempty"`
+	ResolutionTimeMins    *int        `json:"resolutionTimeMins,omitempty"`
+	ResponseTimeMins      *int        `json:"responseTimeMins,omitempty"`
 	Source                *EntityRef  `json:"source,omitempty"`
 	SpamRules             any         `json:"spam_rules"`
-	SpamScore             float64     `json:"spam_score"`
+	SpamScore             *float64    `json:"spam_score,omitempty"`
 	Status                *EntityRef  `json:"status,omitempty"`
-	Subject               string      `json:"subject"`
+	Subject               *string     `json:"subject,omitempty"`
 	Suggestions           struct{}    `json:"suggestions"`
 	Tags                  []EntityRef `json:"tags,omitempty"`
 	Tasks                 []Task      `json:"tasks,omitempty"`

--- a/models/ticket_activity.go
+++ b/models/ticket_activity.go
@@ -3,12 +3,12 @@ package models
 // TicketActivity related types
 type TicketActivity struct {
 	BaseEntity
-	EventType   string    `json:"eventType"`
-	Icon        string    `json:"icon"`
-	Color       string    `json:"color"`
-	TargetAgent EntityRef `json:"targetAgent,omitempty"`
-	Ticket      EntityRef `json:"ticket"`
-	Inbox       any       `json:"inbox"`
-	OldInbox    any       `json:"oldInbox"`
-	Status      EntityRef `json:"status,omitempty"`
+	EventType   *string    `json:"eventType,omitempty"`
+	Icon        *string    `json:"icon,omitempty"`
+	Color       *string    `json:"color,omitempty"`
+	TargetAgent *EntityRef `json:"targetAgent,omitempty"`
+	Ticket      EntityRef  `json:"ticket"`
+	Inbox       any        `json:"inbox"`
+	OldInbox    any        `json:"oldInbox"`
+	Status      *EntityRef `json:"status,omitempty"`
 }

--- a/models/ticket_priority.go
+++ b/models/ticket_priority.go
@@ -3,9 +3,9 @@ package models
 // TicketPriority related types
 type TicketPriority struct {
 	BaseEntity
-	Name         string `json:"name"`
-	Color        string `json:"color"`
-	DisplayOrder int    `json:"displayOrder"`
+	Name         *string `json:"name,omitempty"`
+	Color        *string `json:"color,omitempty"`
+	DisplayOrder *int    `json:"displayOrder,omitempty"`
 }
 
 type TicketPrioritiesResponse struct {

--- a/models/ticket_source.go
+++ b/models/ticket_source.go
@@ -3,10 +3,10 @@ package models
 // TicketSource related types
 type TicketSource struct {
 	BaseEntity
-	Name         string `json:"name"`
-	Icon         string `json:"icon"`
-	DisplayOrder int    `json:"displayOrder"`
-	IsCustom     bool   `json:"isCustom"`
+	Name         *string `json:"name,omitempty"`
+	Icon         *string `json:"icon,omitempty"`
+	DisplayOrder *int    `json:"displayOrder,omitempty"`
+	IsCustom     *bool   `json:"isCustom,omitempty"`
 }
 
 type TicketSourcesResponse struct {

--- a/models/ticket_status.go
+++ b/models/ticket_status.go
@@ -3,12 +3,12 @@ package models
 // TicketStatus related types
 type TicketStatus struct {
 	BaseEntity
-	Code         string `json:"code"`
-	Name         string `json:"name"`
-	DisplayOrder int    `json:"displayOrder"`
-	IsCustom     bool   `json:"isCustom"`
-	Color        string `json:"color"`
-	Icon         string `json:"icon"`
+	Code         *string `json:"code,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	DisplayOrder *int    `json:"displayOrder,omitempty"`
+	IsCustom     *bool   `json:"isCustom,omitempty"`
+	Color        *string `json:"color,omitempty"`
+	Icon         *string `json:"icon,omitempty"`
 }
 
 type TicketStatusesResponse struct {

--- a/models/ticket_type.go
+++ b/models/ticket_type.go
@@ -3,11 +3,11 @@ package models
 // TicketType related types
 type TicketType struct {
 	BaseEntity
-	Name                    string      `json:"name"`
-	DisplayOrder            int         `json:"displayOrder"`
+	Name                    *string     `json:"name,omitempty"`
+	DisplayOrder            *int        `json:"displayOrder,omitempty"`
 	Inboxes                 []EntityRef `json:"inboxes"`
-	Default                 bool        `json:"default"`
-	EnabledForFutureInboxes bool        `json:"enabledForFutureInboxes"`
+	Default                 *bool       `json:"default,omitempty"`
+	EnabledForFutureInboxes *bool       `json:"enabledForFutureInboxes,omitempty"`
 }
 
 type TicketTypesResponse struct {

--- a/models/time_log.go
+++ b/models/time_log.go
@@ -5,15 +5,15 @@ import "time"
 // TimeLog related types
 type TimeLog struct {
 	BaseEntity
-	Billable            bool      `json:"billable"`
-	Description         string    `json:"description"`
-	Date                time.Time `json:"date"`
-	Seconds             int       `json:"seconds"`
-	TimezoneOffset      int       `json:"timezoneOffset"`
-	TimelogsID          any       `json:"timelogs_id"`
-	AssignToCurrentUser bool      `json:"assignToCurrentUser"`
-	Ticket              EntityRef `json:"ticket"`
-	User                EntityRef `json:"user"`
+	Billable            *bool      `json:"billable,omitempty"`
+	Description         *string    `json:"description,omitempty"`
+	Date                *time.Time `json:"date,omitempty"`
+	Seconds             *int       `json:"seconds,omitempty"`
+	TimezoneOffset      *int       `json:"timezoneOffset,omitempty"`
+	TimelogsID          any        `json:"timelogs_id"`
+	AssignToCurrentUser *bool      `json:"assignToCurrentUser,omitempty"`
+	Ticket              EntityRef  `json:"ticket"`
+	User                EntityRef  `json:"user"`
 }
 
 type TimeLogsResponse struct {

--- a/models/user.go
+++ b/models/user.go
@@ -3,24 +3,24 @@ package models
 // User related types
 type User struct {
 	BaseEntity
-	Email                    string    `json:"email"`
-	FirstName                string    `json:"firstName"`
-	LastName                 string    `json:"lastName"`
-	AvatarURL                string    `json:"avatarURL"`
-	EditMethod               string    `json:"editMethod"`
-	IsPartTime               bool      `json:"isPartTime"`
-	TicketReplyRedirect      string    `json:"ticketReplyRedirect"`
-	Reviewer                 bool      `json:"reviewer"`
-	TrainingWheelsEnrollment EntityRef `json:"trainingWheelsEnrollment"`
-	Role                     string    `json:"role"`
-	SendPushNotifications    bool      `json:"sendPushNotifications"`
-	SendWebNotifications     bool      `json:"sendWebNotifications"`
-	AutoFollowOnCC           bool      `json:"autoFollowOnCC"`
-	TimeFormatID             int       `json:"timeFormatId"`
-	TimezoneID               int       `json:"timezoneId"`
-	ProjectsCompanyID        int       `json:"projectsCompanyId"`
-	IsAppOwner               bool      `json:"isAppOwner"`
-	LdKey                    string    `json:"ldKey"`
+	Email                    *string    `json:"email,omitempty"`
+	FirstName                *string    `json:"firstName,omitempty"`
+	LastName                 *string    `json:"lastName,omitempty"`
+	AvatarURL                *string    `json:"avatarURL,omitempty"`
+	EditMethod               *string    `json:"editMethod,omitempty"`
+	IsPartTime               *bool      `json:"isPartTime,omitempty"`
+	TicketReplyRedirect      *string    `json:"ticketReplyRedirect,omitempty"`
+	Reviewer                 *bool      `json:"reviewer,omitempty"`
+	TrainingWheelsEnrollment *EntityRef `json:"trainingWheelsEnrollment,omitempty"`
+	Role                     *string    `json:"role,omitempty"`
+	SendPushNotifications    *bool      `json:"sendPushNotifications,omitempty"`
+	SendWebNotifications     *bool      `json:"sendWebNotifications,omitempty"`
+	AutoFollowOnCC           *bool      `json:"autoFollowOnCC,omitempty"`
+	TimeFormatID             *int       `json:"timeFormatId,omitempty"`
+	TimezoneID               *int       `json:"timezoneId,omitempty"`
+	ProjectsCompanyID        *int       `json:"projectsCompanyId,omitempty"`
+	IsAppOwner               *bool      `json:"isAppOwner,omitempty"`
+	LdKey                    *string    `json:"ldKey,omitempty"`
 }
 
 type UsersResponse struct {


### PR DESCRIPTION
All Get and List endpoints now accept a fields param to request sparse fieldsets from the API. Get methods take url.Values (with GetOptions as a builder that defaults includes=all); List already used url.Values.

All scalar fields in domain models (bool, int, float64, string, named types) are now pointer types with omitempty, so callers can distinguish a field that was not returned (nil) from a field returned as its zero value. Required ref fields and infrastructure types (Pagination, Meta, IncludedData) are left as value types.